### PR TITLE
chore: move initial config manipulation to generator job

### DIFF
--- a/resources/cluster/kustomization.yaml
+++ b/resources/cluster/kustomization.yaml
@@ -20,102 +20,25 @@ commonLabels:
   cluster.x-k8s.io/cluster-name: mycluster
 configMapGenerator:
 - name: config
+  behavior: merge
   literals:
-  - POD_SUBNET=10.246.0.0/16
-  - SERVICE_SUBNET=10.112.0.0/16
-  - NAME_PREFIX=
+  - CLUSTER_NAME=mycluster
+  - POD_SUBNETS=["10.246.0.0/16"]
+  - SERVICE_SUBNETS=["10.112.0.0/16"]
 patches:
 - target:
     group: apps
     version: v1
     labelselector: app.kubernetes.io/name=talos,app.kubernetes.io/component=node
   patch: |-
-    - op: add
-      path: /spec/template/spec/volumes/-
-      value:
-        name: talos-configs
-        secret:
-          secretName: mycluster
-          optional: false
-    - op: add
-      path: /spec/template/spec/volumes/-
-      value:
-        name: podinfo
-        downwardAPI:
-          items:
-            - path: "labels"
-              fieldRef:
-                fieldPath: metadata.labels
-
-    - op: add
-      path: /spec/template/spec/initContainers/-
-      value:
-        name: config-select
-        image: docker.io/library/alpine
-        command:
-        - sh
-        - -ec
-        - |-
-          cfg_file=join.yaml
-          if cat /podinfo/labels | grep -Fq "node-role.kubernetes.io/control-plane="; then
-            cfg_file=controlplane.yaml
-          fi
-          mkdir -p /system/state
-          cp "/talos-configs/${cfg_file}" /system/state/config.yaml
-        volumeMounts:
-        - name: talos-configs
-          mountPath: /talos-configs
-        - name: system
-          mountPath: /system
-        - name: podinfo
-          mountPath: /podinfo
-
-    - op: add
-      path: /spec/template/spec/initContainers/-
-      value:
-        name: config-tink
-        image: docker.io/mikefarah/yq
-        command:
-        - sh
-        - -ec
-        - |-
-          prefix="$(NAME_PREFIX)"
-          cluster_name="$(CLUSTER_NAME)"
-          pod_subnet="$(POD_SUBNET)"
-          service_subnet="$(SERVICE_SUBNET)"
-          nameserver="$(cat /etc/resolv.conf|grep -E '^nameserver '|awk '{print $2}')"
-          ns_domain="$(cat /etc/resolv.conf|grep -E '^search '|awk '{print $2}')"
-          certSANs='[
-            "127.0.0.1",
-            "localhost",
-            "'${prefix}'controlplane.'${ns_domain}'",
-            "'${prefix}'controlplane-0.'${prefix}'controlplane.'${ns_domain}'",
-            "'${prefix}'controlplane-1.'${prefix}'controlplane.'${ns_domain}'",
-            "'${prefix}'controlplane-2.'${prefix}'controlplane.'${ns_domain}'"
-          ]'
-
-          config_set() {
-            expr="${1}"
-            value="${2}"
-            yq eval --inplace "${expr} = ${value}" /system/state/config.yaml
-          }
-
-          config_set ".machine.network.nameservers" '["'${nameserver}'"]'
-          config_set ".machine.certSANs" "${certSANs}"
-          config_set ".cluster.apiServer.certSANs" "${certSANs}"
-          config_set ".cluster.network.dnsDomain" "\"${cluster_name}.local\""
-          config_set ".cluster.network.podSubnets" '["'${pod_subnet}'"]'
-          config_set ".cluster.network.serviceSubnets" '["'${service_subnet}'"]'
-        envFrom:
-        - configMapRef:
-            name: config
-        env:
-        - name: CLUSTER_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.labels['cluster.x-k8s.io/cluster-name']
-        volumeMounts:
-        - name: talos-configs
-          mountPath: /talos-configs
-        - name: system
-          mountPath: /system
+    apiVersion: apps/v1
+    kind: SomeNode
+    metadata:
+      name: some-node
+    spec:
+      template:
+        spec:
+          volumes:
+          - name: talos-config
+            secret:
+              secretName: mycluster

--- a/resources/generate-talos-config-secret/job.yaml
+++ b/resources/generate-talos-config-secret/job.yaml
@@ -17,18 +17,48 @@ spec:
         - gen
         - config
         - $(CLUSTER_NAME)
-        - "https://controlplane.$(NAMESPACE).svc.$(HOST_CLUSTER_DOMAIN):6443"
-        env:
-        - name: CLUSTER_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.labels['cluster.x-k8s.io/cluster-name']
-        - name: NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: HOST_CLUSTER_DOMAIN
-          value: cluster.local
+        - https://$(CONTROLPLANE_SERVICE_FQDN):$(CONTROLPLANE_SERVICE_PORT)
+        envFrom:
+        - configMapRef:
+            name: config
+        volumeMounts:
+        - name: talos-config
+          mountPath: /talos-config
+      - name: tink-config
+        workingDir: /talos-config
+        image: docker.io/mikefarah/yq
+        command:
+        - sh
+        - -ec
+        - |-
+          podSubnets="${POD_SUBNETS}"
+          serviceSubnets="${SERVICE_SUBNETS}"
+          certSANs="${CERT_SANS}"
+          dnsDomain="${CLUSTER_DOMAIN}"
+
+          nameservers="${NAMESERVERS}"
+          if [ -z "${nameservers}" ]; then
+            nameservers="$(cat /etc/resolv.conf|grep -E '^nameserver '|awk '{print $2}')"
+            nameservers='["'${nameservers}'"]'
+          fi
+
+          config_set() {
+            expr="${1}"
+            value="${2}"
+            yq eval --inplace "${expr} = ${value}" init.yaml
+            yq eval --inplace "${expr} = ${value}" controlplane.yaml
+            yq eval --inplace "${expr} = ${value}" join.yaml
+          }
+
+          config_set ".machine.network.nameservers" "${nameservers}"
+          config_set ".machine.certSANs" "${certSANs}"
+          config_set ".cluster.apiServer.certSANs" "${certSANs}"
+          config_set ".cluster.network.dnsDomain" "\"${dnsDomain}\""
+          config_set ".cluster.network.podSubnets" "${podSubnets}"
+          config_set ".cluster.network.serviceSubnets" "${serviceSubnets}"
+        envFrom:
+        - configMapRef:
+            name: config
         volumeMounts:
         - name: talos-config
           mountPath: /talos-config
@@ -45,11 +75,9 @@ spec:
         - --from-file=init.yaml
         - --from-file=join.yaml
         - --from-file=talosconfig
-        env:
-        - name: CLUSTER_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.labels['cluster.x-k8s.io/cluster-name']
+        envFrom:
+        - configMapRef:
+            name: config
         volumeMounts:
         - name: talos-config
           mountPath: /talos-config

--- a/resources/generate-talos-config-secret/kustomization.yaml
+++ b/resources/generate-talos-config-secret/kustomization.yaml
@@ -6,5 +6,34 @@ resources:
 - rolebinding.yaml
 - serviceaccount.yaml
 commonLabels:
-  cluster.x-k8s.io/cluster-name: my-cluster
-  app.kubernetes.io/component: bootstrap
+  app.kubernetes.io/component: generate-talos-config-secret
+configMapGenerator:
+- name: config
+  literals:
+  - CLUSTER_NAME=tint
+  - CLUSTER_DOMAIN=tint.local
+  - CONTROLPLANE_SERVICE_FQDN=controlplane.default.svc.cluster.local
+  - CONTROLPLANE_SERVICE_PORT=6443
+  - POD_SUBNETS=["10.244.0.0/16"]
+  - SERVICE_SUBNETS=["10.96.0.0/12"]
+  - |-
+    CERT_SANS=[
+      "127.0.0.1",
+      "localhost",
+      "controlplane",
+      "controlplane.default",
+      "controlplane.default.svc",
+      "controlplane.default.svc.cluster.local",
+      "controlplane-0.controlplane",
+      "controlplane-0.controlplane.default",
+      "controlplane-0.controlplane.default.svc",
+      "controlplane-0.controlplane.default.svc.cluster.local",
+      "controlplane-1.controlplane",
+      "controlplane-1.controlplane.default",
+      "controlplane-1.controlplane.default.svc",
+      "controlplane-1.controlplane.default.svc.cluster.local",
+      "controlplane-2.controlplane",
+      "controlplane-2.controlplane.default",
+      "controlplane-2.controlplane.default.svc",
+      "controlplane-2.controlplane.default.svc.cluster.local"
+    ]

--- a/resources/node/common/kustomization.yaml
+++ b/resources/node/common/kustomization.yaml
@@ -9,12 +9,26 @@ patches:
     version: v1
   patch: |-
     apiVersion: apps/v1
-    kind: StatefulSet
+    kind: DoesNotMatter
     metadata:
-      name: node
+      name: does-not-matter
     spec:
       template:
         spec:
+          initContainers:
+          - name: copy-config
+            image: docker.io/library/alpine
+            command:
+            - sh
+            - -ec
+            - |-
+              mkdir -p /system/state
+              cp /talos-config/config.yaml /system/state/config.yaml
+            volumeMounts:
+            - name: talos-config
+              mountPath: /talos-config
+            - name: system
+              mountPath: /system
           containers:
           - name: talos
             image: ghcr.io/talos-systems/talos

--- a/resources/node/controlplane/statefulset.yaml
+++ b/resources/node/controlplane/statefulset.yaml
@@ -14,3 +14,14 @@ spec:
           name: kube-api
         - containerPort: 50000
           name: talos-api
+        volumeMounts:
+        - name: talos-config
+          mountPath: /talos-config
+      volumes:
+      - name: talos-config
+        secret:
+          secretName: tint
+          items:
+          - key: controlplane.yaml
+            path: config.yaml
+          optional: false

--- a/resources/node/worker/deployment.yaml
+++ b/resources/node/worker/deployment.yaml
@@ -8,3 +8,14 @@ spec:
       initContainers: []
       containers:
       - name: talos
+        volumeMounts:
+        - name: talos-config
+          mountPath: /talos-config
+      volumes:
+      - name: talos-config
+        secret:
+          secretName: tint
+          items:
+          - key: join.yaml
+            path: config.yaml
+          optional: false


### PR DESCRIPTION
This puts more focus on the cluster's configmap for initial config.

Fixes https://github.com/bzub/tink/issues/5