### PR TITLE
fix: remove hard-coded namespace references

### DIFF
--- a/resources/cluster/kustomization.yaml
+++ b/resources/cluster/kustomization.yaml
@@ -1,14 +1,15 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+
 resources:
-- ../config
 - ../node/controlplane
 - ../node/worker
 - ../bootstrap
 - ../generate-talos-config-secret
+
 components:
 - ../node/common
-namespace: default
+
 images:
 - name: ghcr.io/siderolabs/talos
   newTag: v1.7.6
@@ -18,6 +19,7 @@ images:
   newTag: 4.44.3
 - name: docker.io/bitnami/kubectl
   newTag: 1.29.7
+
 commonLabels:
   app.kubernetes.io/name: talos
   app.kubernetes.io/instance: mycluster
@@ -25,11 +27,11 @@ commonLabels:
 
 configMapGenerator:
 - name: config
-  behavior: merge
+  behavior: create
   literals:
   - CLUSTER_NAME=mycluster
   - CLUSTER_DOMAIN=mycluster.local
-  - CONTROLPLANE_SERVICE_FQDN=controlplane.default.svc.cluster.local
+  - CONTROLPLANE_SERVICE_FQDN=controlplane
   - CONTROLPLANE_SERVICE_PORT=6443
 
 patches:

--- a/resources/config/kustomization.yaml
+++ b/resources/config/kustomization.yaml
@@ -1,9 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-configMapGenerator:
-- name: config
-  literals:
-  - CLUSTER_NAME=tink
-  - CLUSTER_DOMAIN=tink.local
-  - CONTROLPLANE_SERVICE_FQDN=controlplane.default.svc.cluster.local
-  - CONTROLPLANE_SERVICE_PORT=6443

--- a/resources/generate-talos-config-secret/job.yaml
+++ b/resources/generate-talos-config-secret/job.yaml
@@ -22,7 +22,7 @@ spec:
         - --with-examples=false
         - --with-cluster-discovery=false
         - --with-kubespan=false
-        - --additional-sans="controlplane.default.svc.cluster.local"
+        - --additional-sans="$(CONTROLPLANE_SERVICE_FQDN)"
         - --additional-sans="localhost"
         # See: https://www.talos.dev/v1.7/talos-guides/install/cloud-platforms/kubernetes/#machine-configuration
         - |-


### PR DESCRIPTION
Also:
- Removed the redundant `resources/config` kustomization.

Fixes: https://github.com/bzub/tink/issues/21